### PR TITLE
Refactor API composables to use `useApi` instead of `useEnfyraApi` ac…

### DIFF
--- a/app/components/dynamic/PageComponent.vue
+++ b/app/components/dynamic/PageComponent.vue
@@ -66,7 +66,7 @@
 </template>
 
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 interface Props {
   path: string;
 }
@@ -85,7 +85,7 @@ const {
   error: menuError,
   pending: loading,
   execute: executeFetchMenu,
-} = useEnfyraApi(() => "/menu_definition", {
+} = useApi(() => "/menu_definition", {
   query: computed(() => ({
     fields: "*,extension.*",
     filter: {

--- a/app/components/dynamic/WidgetComponent.vue
+++ b/app/components/dynamic/WidgetComponent.vue
@@ -48,7 +48,7 @@
 </template>
 
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 interface Props {
   id: string | number;
 }
@@ -72,7 +72,7 @@ const {
   error: extensionError,
   pending: loading,
   execute: executeFetchExtension,
-} = useEnfyraApi(() => "/extension_definition", {
+} = useApi(() => "/extension_definition", {
   query: computed(() => ({
     fields: "*",
     filter: {

--- a/app/components/file/FileGrid.vue
+++ b/app/components/file/FileGrid.vue
@@ -47,7 +47,7 @@ import { formatFileSize } from "~/utils/file-management/file-utils";
 import type { FileItem } from "~/utils/types";
 import FileGridCard from "./grid/FileGridCard.vue";
 import { useFileUrl } from "~/composables/file-manager/useFileUrl";
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 
 interface Props {
   files: FileItem[];
@@ -98,7 +98,7 @@ const { confirm } = useConfirm();
 const toast = useToast();
 
 // Delete file API
-const { execute: executeDeleteFile } = useEnfyraApi(() => `/file_definition`, {
+const { execute: executeDeleteFile } = useApi(() => `/file_definition`, {
   method: "delete",
   errorContext: "Delete File",
 });

--- a/app/components/file/FileManager.vue
+++ b/app/components/file/FileManager.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 interface Props {
   parentId?: string;
   folders?: any[];
@@ -192,7 +192,7 @@ async function handleBulkDelete() {
 
   if (folderIds.length > 0) {
     selectedFolders.value = folderIds;
-    const { execute: deleteFolderApi, error: deleteFolderError } = useEnfyraApi(
+    const { execute: deleteFolderApi, error: deleteFolderError } = useApi(
       () => "/folder_definition",
       { method: "delete", errorContext: "Delete Folder" }
     );
@@ -204,7 +204,7 @@ async function handleBulkDelete() {
   }
 
   if (fileIds.length > 0 && !deletionErrors) {
-    const { execute: deleteFileApi, error: deleteFileError } = useEnfyraApi(
+    const { execute: deleteFileApi, error: deleteFileError } = useApi(
       () => "/file_definition",
       { method: "delete", errorContext: "Delete File" }
     );

--- a/app/components/file/grid/FileGridCard.vue
+++ b/app/components/file/grid/FileGridCard.vue
@@ -75,7 +75,7 @@
 </template>
 
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 import type { FileItem } from "~/utils/types";
 import Preview from "./FileGridPreview.vue";
 import EditableName from "./FileGridEditableName.vue";
@@ -184,7 +184,7 @@ async function saveEdit() {
   editingLoading.value = true;
 
   try {
-    const { execute: updateFile, error } = useEnfyraApi(
+    const { execute: updateFile, error } = useApi(
       () => `file_definition/${props.file.id}`,
       {
         method: "patch",

--- a/app/components/folder/CreateModal.vue
+++ b/app/components/folder/CreateModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 const props = defineProps<{
   modelValue: boolean;
   parentId?: string;
@@ -19,7 +19,7 @@ const {
   pending: createLoading,
   execute: createFolder,
   error: createError,
-} = useEnfyraApi(() => "/folder_definition", {
+} = useApi(() => "/folder_definition", {
   method: "post",
   errorContext: "Create Folder",
 });

--- a/app/components/folder/FolderGrid.vue
+++ b/app/components/folder/FolderGrid.vue
@@ -40,7 +40,7 @@
 </template>
 
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 import { formatDate } from "~/utils/common/filter/filter-helpers";
 import {
   getFolderIcon,
@@ -95,7 +95,7 @@ const { confirm } = useConfirm();
 const toast = useToast();
 
 // Delete folder API at setup level
-const { execute: executeDeleteFolder } = useEnfyraApi(
+const { execute: executeDeleteFolder } = useApi(
   () => `/folder_definition`,
   {
     method: "delete",

--- a/app/components/folder/grid/Card.vue
+++ b/app/components/folder/grid/Card.vue
@@ -86,7 +86,7 @@
 </template>
 
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 
 interface Props {
   folder: any;
@@ -177,7 +177,7 @@ async function saveEdit() {
   editingLoading.value = true;
 
   try {
-    const { execute: updateFolder, error } = useEnfyraApi(
+    const { execute: updateFolder, error } = useApi(
       () => `folder_definition/${props.folder.id}`,
       {
         method: "patch",

--- a/app/components/form/permission/RoutePicker.vue
+++ b/app/components/form/permission/RoutePicker.vue
@@ -178,7 +178,7 @@
 </template>
 
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 
 const props = defineProps<{
   modelValue: boolean;
@@ -210,7 +210,7 @@ const {
   data: apiData,
   pending: loading,
   execute: fetchRoutes,
-} = useEnfyraApi(() => "/route_definition", {
+} = useApi(() => "/route_definition", {
   query: computed(() => {
     const filterQuery = hasActiveFilters(currentFilter.value)
       ? buildQuery(currentFilter.value)

--- a/app/components/form/relation/CreateDrawer.vue
+++ b/app/components/form/relation/CreateDrawer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 
 const props = defineProps<{
   modelValue: boolean;
@@ -23,7 +23,7 @@ const {
   data: createData,
   pending: creating,
   execute: createRecord,
-} = useEnfyraApi(() => `/${targetTable?.name}`, {
+} = useApi(() => `/${targetTable?.name}`, {
   method: "post",
   errorContext: "Create Relation Record",
 });

--- a/app/components/form/relation/Selector.vue
+++ b/app/components/form/relation/Selector.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 
 const props = defineProps<{
   relationMeta: any;
@@ -53,7 +53,7 @@ const {
   pending: loading,
   execute: fetchData,
   error: apiError,
-} = useEnfyraApi(() => `/${targetTable.value?.name}`, {
+} = useApi(() => `/${targetTable.value?.name}`, {
   query: computed(() => {
     const filterQuery = hasActiveFilters(currentFilter.value)
       ? buildQuery(currentFilter.value)

--- a/app/components/permission/PermissionManager.vue
+++ b/app/components/permission/PermissionManager.vue
@@ -200,7 +200,7 @@
 </template>
 
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 import { UIcon } from "#components";
 
 const toast = useToast();
@@ -245,7 +245,7 @@ const {
   data: permissionsData,
   pending: loading,
   execute: fetchPermissions,
-} = useEnfyraApi(() => `/${permissionTableName.value}`, {
+} = useApi(() => `/${permissionTableName.value}`, {
   query: {
     filter: {
       [props.currentFieldId.field]: {
@@ -260,7 +260,7 @@ const {
   error: createError,
   execute: createPermission,
   pending: creating,
-} = useEnfyraApi(() => `/${permissionTableName.value}`, {
+} = useApi(() => `/${permissionTableName.value}`, {
   method: "post",
   errorContext: "Create Permission",
 });
@@ -269,7 +269,7 @@ const {
   error: updateError,
   execute: updatePermission,
   pending: updating,
-} = useEnfyraApi(() => `/${permissionTableName.value}`, {
+} = useApi(() => `/${permissionTableName.value}`, {
   method: "patch",
   errorContext: "Update Permission",
 });
@@ -278,7 +278,7 @@ const {
   error: deleteError,
   execute: deletePermissionApi,
   pending: deletePending,
-} = useEnfyraApi(() => `/${permissionTableName.value}`, {
+} = useApi(() => `/${permissionTableName.value}`, {
   method: "delete",
   errorContext: "Delete Permission",
 });

--- a/app/composables/data-table/useDataTableActions.ts
+++ b/app/composables/data-table/useDataTableActions.ts
@@ -13,7 +13,7 @@ export function useDataTableActions(
   const { createLoader } = useLoader();
 
   // Delete single record composable
-  const { execute: executeDelete, error: deleteError } = useEnfyraApi(
+  const { execute: executeDelete, error: deleteError } = useApi(
     () => `/${tableName}`,
     {
       method: "delete",

--- a/app/composables/dynamic/useDynamicComponent.ts
+++ b/app/composables/dynamic/useDynamicComponent.ts
@@ -45,7 +45,7 @@ import {
   usePermissions,
   useFilterQuery,
   useDataTableColumns,
-  useEnfyraApi,
+  useApi,
   // Nuxt composables
   useToast,
   useState,
@@ -234,7 +234,7 @@ export const useDynamicComponent = () => {
       // Direct injection - no need for createComposableMap filtering
       const composables = {
         // Enfyra composables
-        useEnfyraApi,
+        useApi,
         useHeaderActionRegistry,
         useSubHeaderActionRegistry,
         useSchema,

--- a/app/composables/file-manager/useFileManager.ts
+++ b/app/composables/file-manager/useFileManager.ts
@@ -2,7 +2,7 @@
 export function useFileManager(parentFilter?: any) {
   // API call for folders (only if parentFilter is provided)
   const apiCall = parentFilter
-    ? useEnfyraApi(() => "folder_definition", {
+    ? useApi(() => "folder_definition", {
         query: computed(() => ({
           limit: 100,
           fields: "*",
@@ -18,7 +18,7 @@ export function useFileManager(parentFilter?: any) {
   const { confirm } = useConfirm();
 
   // API calls at setup level (following best practices)
-  const { execute: deleteFolderApi, error: deleteFolderError } = useEnfyraApi(
+  const { execute: deleteFolderApi, error: deleteFolderError } = useApi(
     () => "/folder_definition",
     {
       method: "delete",
@@ -26,7 +26,7 @@ export function useFileManager(parentFilter?: any) {
     }
   );
 
-  const { execute: deleteFileApi, error: deleteFileError } = useEnfyraApi(
+  const { execute: deleteFileApi, error: deleteFileError } = useApi(
     () => "/file_definition",
     {
       method: "delete",

--- a/app/composables/file-manager/useFileManagerMove.ts
+++ b/app/composables/file-manager/useFileManagerMove.ts
@@ -1,4 +1,4 @@
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 
 export function useFileManagerMove() {
   // File Manager Move State
@@ -24,7 +24,7 @@ export function useFileManagerMove() {
     execute: patchFiles,
     error: patchFilesError,
     pending: patchFilesPending,
-  } = useEnfyraApi(() => "/file_definition", {
+  } = useApi(() => "/file_definition", {
     method: "patch",
     errorContext: "Move Files",
   });
@@ -33,7 +33,7 @@ export function useFileManagerMove() {
     execute: patchFolders,
     error: patchFoldersError,
     pending: patchFoldersPending,
-  } = useEnfyraApi(() => "/folder_definition", {
+  } = useApi(() => "/folder_definition", {
     method: "patch",
     errorContext: "Move Folders",
   });

--- a/app/composables/menu/useMenuApi.ts
+++ b/app/composables/menu/useMenuApi.ts
@@ -3,7 +3,7 @@ export const useMenuApi = () => {
     data: menuDefinitions,
     pending: menuDefinitionsPending,
     execute: fetchMenuDefinitions,
-  } = useEnfyraApi<{ data: MenuApiItem[] }>(() => "/menu_definition", {
+  } = useApi<{ data: MenuApiItem[] }>(() => "/menu_definition", {
     query: computed(() => ({
       limit: 0,
       fields: "*,parent.*,children.*,sidebar.*",

--- a/app/composables/shared/useGlobalState.ts
+++ b/app/composables/shared/useGlobalState.ts
@@ -19,7 +19,7 @@ export const useGlobalState = () => {
     data: settingsData,
     pending: settingsPending,
     execute: executeFetchSettings,
-  } = useEnfyraApi(() => "/setting_definition", {
+  } = useApi(() => "/setting_definition", {
     query: {
       fields: ["*", "methods.*"].join(","),
       limit: 0,

--- a/app/composables/shared/useSchema.ts
+++ b/app/composables/shared/useSchema.ts
@@ -16,7 +16,7 @@ export function useSchema(tableName?: string | Ref<string>) {
     data: tablesData,
     pending: tablesPending,
     execute: executeFetchTables,
-  } = useEnfyraApi(() => "/table_definition", {
+  } = useApi(() => "/table_definition", {
     query: {
       fields: ["*", "columns.*", "relations.*"].join(","),
       limit: 0,

--- a/app/composables/useApi.ts
+++ b/app/composables/useApi.ts
@@ -1,0 +1,43 @@
+export function useApi<T = any>(url: string | (() => string), options?: any) {
+  const toast = useToast();
+
+  const { data, pending, error, refresh, execute, status } = useEnfyraApi<T>(
+    url,
+    {
+      ...options,
+      onError: (error: any) => {
+        const errorMessage =
+          error?.data?.message || error?.message || "An error occurred";
+
+        toast.add({
+          title: "Error",
+          description: errorMessage,
+          color: "error",
+        });
+
+        if (options?.onError) {
+          options.onError(error);
+        }
+      },
+    }
+  );
+
+  return {
+    data,
+    pending,
+    error,
+    refresh,
+    execute,
+    status,
+  };
+}
+
+export function useApiLazy<T = any>(
+  url: string | (() => string),
+  options?: any
+) {
+  return useApi<T>(url, {
+    ...options,
+    immediate: false,
+  });
+}

--- a/app/pages/collections/[table].vue
+++ b/app/pages/collections/[table].vue
@@ -15,7 +15,7 @@ const {
   data: tableData,
   pending: loading,
   execute: fetchTableData,
-} = useEnfyraApi(() => "/table_definition", {
+} = useApi(() => "/table_definition", {
   query: computed(() => ({
     fields: getIncludeFields(),
     filter: {
@@ -31,7 +31,7 @@ const {
   pending: saving,
   execute: executePatchTable,
   error: updateError,
-} = useEnfyraApi(() => `/table_definition`, {
+} = useApi(() => `/table_definition`, {
   method: "patch",
   body: computed(() => table.value),
   errorContext: "Update Table",
@@ -41,7 +41,7 @@ const {
   pending: deleting,
   execute: executeDeleteTable,
   error: deleteError,
-} = useEnfyraApi(() => `/table_definition`, {
+} = useApi(() => `/table_definition`, {
   method: "delete",
   errorContext: "Delete Table",
 });
@@ -133,7 +133,7 @@ async function patchTable() {
   await executePatchTable({ id: table.value?.id });
 
   if (updateError.value) {
-    return; // Error already handled by useEnfyraApi
+    return; // Error already handled by useApi
   }
 
   await fetchSchema();
@@ -162,7 +162,7 @@ async function deleteTable() {
   await executeDeleteTable({ id: table.value?.id });
 
   if (deleteError.value) {
-    return; // Error already handled by useEnfyraApi
+    return; // Error already handled by useApi
   }
 
   await fetchSchema();

--- a/app/pages/collections/create.vue
+++ b/app/pages/collections/create.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 
 const { schemas, fetchSchema, schemaLoading } = useSchema();
 const { confirm } = useConfirm();
@@ -110,7 +110,7 @@ const {
   pending: createLoading,
   execute: createTable,
   error: createError,
-} = useEnfyraApi("/table_definition", {
+} = useApi("/table_definition", {
   method: "post",
   errorContext: "Create Table",
 });

--- a/app/pages/data/[table]/[id].vue
+++ b/app/pages/data/[table]/[id].vue
@@ -14,7 +14,7 @@ const {
   data: apiData,
   pending: loading,
   execute: fetchRecord,
-} = useEnfyraApi(() => `/${route.params.table}`, {
+} = useApi(() => `/${route.params.table}`, {
   query: computed(() => ({
     fields: "*",
     filter: {
@@ -77,7 +77,7 @@ const {
   pending: updateLoading,
   execute: updateRecord,
   error: updateError,
-} = useEnfyraApi(() => `/${route.params.table}`, {
+} = useApi(() => `/${route.params.table}`, {
   method: "patch",
   errorContext: "Update Record",
 });
@@ -86,7 +86,7 @@ const {
   error: deleteError,
   execute: executeDeleteRecord,
   pending: deleteLoading,
-} = useEnfyraApi(() => `/${route.params.table}`, {
+} = useApi(() => `/${route.params.table}`, {
   method: "delete",
   errorContext: "Delete Record",
 });

--- a/app/pages/data/[table]/create.vue
+++ b/app/pages/data/[table]/create.vue
@@ -11,7 +11,7 @@ const {
   pending: createLoading,
   execute: createRecord,
   error: createError,
-} = useEnfyraApi(() => `/${route.params.table}`, {
+} = useApi(() => `/${route.params.table}`, {
   method: "post",
   errorContext: "Create Record",
 });

--- a/app/pages/data/[table]/index.vue
+++ b/app/pages/data/[table]/index.vue
@@ -35,7 +35,7 @@ const {
   data: apiData,
   pending: loading,
   execute: fetchData,
-} = useEnfyraApi(() => `/${tableName}`, {
+} = useApi(() => `/${tableName}`, {
   query: computed(() => {
     const filterQuery = hasActiveFilters(currentFilter.value)
       ? buildQuery(currentFilter.value)

--- a/app/pages/files/[id].vue
+++ b/app/pages/files/[id].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 
 const route = useRoute();
 const router = useRouter();
@@ -14,7 +14,7 @@ const {
   pending,
   error,
   execute,
-} = useEnfyraApi(`/file_definition`, {
+} = useApi(`/file_definition`, {
   query: {
     filter: {
       id: {
@@ -34,7 +34,7 @@ const {
   error: updateError,
   execute: executeUpdateFile,
   pending: updateLoading,
-} = useEnfyraApi(`/file_definition`, {
+} = useApi(`/file_definition`, {
   method: "patch",
   errorContext: "Update File",
 });
@@ -43,7 +43,7 @@ const {
   error: deleteError,
   execute: executeDeleteFile,
   pending: deleteLoading,
-} = useEnfyraApi(`/file_definition`, {
+} = useApi(`/file_definition`, {
   method: "delete",
   errorContext: "Delete File",
 });

--- a/app/pages/files/management/[id].vue
+++ b/app/pages/files/management/[id].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 const route = useRoute();
 const router = useRouter();
 const showCreateModal = ref(false);
@@ -14,7 +14,7 @@ const {
   data: folder,
   pending: folderPending,
   execute: fetchFolder,
-} = useEnfyraApi(() => `/folder_definition`, {
+} = useApi(() => `/folder_definition`, {
   query: computed(() => ({
     filter: {
       id: {
@@ -66,7 +66,7 @@ const {
   execute: uploadFilesApi,
   error: uploadError,
   pending: uploadPending,
-} = useEnfyraApi(() => `file_definition`, {
+} = useApi(() => `file_definition`, {
   method: "post",
   errorContext: "Upload Files",
 });
@@ -150,7 +150,7 @@ async function handleFileUpload(files: File | File[]) {
 
   // Check for errors
   if (uploadError.value) {
-    return; // Error already handled by useEnfyraApi
+    return; // Error already handled by useApi
   }
 
   await fetchFolder();

--- a/app/pages/files/management/index.vue
+++ b/app/pages/files/management/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 const showCreateModal = ref(false);
 const showUploadModal = ref(false);
 
@@ -14,7 +14,7 @@ const {
   data: rootFolders,
   pending: rootPending,
   execute: fetchRootFolders,
-} = useEnfyraApi(() => `folder_definition`, {
+} = useApi(() => `folder_definition`, {
   query: computed(() => ({
     limit,
     page: folderPage.value,
@@ -35,7 +35,7 @@ const {
   data: rootFiles,
   pending: filesPending,
   execute: fetchRootFiles,
-} = useEnfyraApi(() => `file_definition`, {
+} = useApi(() => `file_definition`, {
   query: computed(() => ({
     limit,
     page: filePage.value,
@@ -57,7 +57,7 @@ const {
   execute: uploadFilesApi,
   error: uploadError,
   pending: uploadPending,
-} = useEnfyraApi(() => `file_definition`, {
+} = useApi(() => `file_definition`, {
   method: "post",
   errorContext: "Upload Files",
 });
@@ -161,7 +161,7 @@ async function handleFileUpload(files: File | File[]) {
 
   // Check for errors
   if (uploadError.value) {
-    return; // Error already handled by useEnfyraApi
+    return; // Error already handled by useApi
   }
 
   // Refresh files list after successful upload

--- a/app/pages/settings/extensions/[id].vue
+++ b/app/pages/settings/extensions/[id].vue
@@ -76,7 +76,7 @@
 </template>
 
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 definePageMeta({
   layout: "default",
   title: "Extension Detail",
@@ -158,7 +158,7 @@ const {
   data: extensionData,
   pending: loading,
   execute: executeGetExtension,
-} = useEnfyraApi(() => `/${tableName}`, {
+} = useApi(() => `/${tableName}`, {
   query: {
     fields: getIncludeFields(),
     filter: { id: { _eq: route.params.id } },
@@ -170,7 +170,7 @@ const {
   error: updateError,
   execute: executeUpdateExtension,
   pending: updateLoading,
-} = useEnfyraApi(() => `/${tableName}`, {
+} = useApi(() => `/${tableName}`, {
   method: "patch",
   errorContext: "Update Extension",
 });
@@ -179,7 +179,7 @@ const {
   error: deleteError,
   execute: executeDeleteExtension,
   pending: deleteLoading,
-} = useEnfyraApi(() => `/${tableName}`, {
+} = useApi(() => `/${tableName}`, {
   method: "delete",
   errorContext: "Delete Extension",
 });

--- a/app/pages/settings/extensions/create.vue
+++ b/app/pages/settings/extensions/create.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 definePageMeta({
   layout: "default",
   title: "Create Extension",
@@ -106,13 +106,13 @@ useHeaderActionRegistry({
   },
 });
 
-// Setup useEnfyraApi composable at top level
+// Setup useApi composable at top level
 const {
   data: createData,
   error: createError,
   execute: executeCreateExtension,
   pending: createLoading,
-} = useEnfyraApi(() => `/${tableName}`, {
+} = useApi(() => `/${tableName}`, {
   method: "post",
   errorContext: "Create Extension",
 });

--- a/app/pages/settings/extensions/index.vue
+++ b/app/pages/settings/extensions/index.vue
@@ -97,7 +97,7 @@
 </template>
 
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 
 const page = ref(1);
 const limit = 9;
@@ -114,7 +114,7 @@ const {
   data: apiData,
   pending: loading,
   execute: fetchExtensions,
-} = useEnfyraApi(() => "/extension_definition", {
+} = useApi(() => "/extension_definition", {
   query: computed(() => ({
     fields: ["*", "menu.*"].join(","),
     limit,
@@ -130,7 +130,7 @@ const total = computed(() => apiData.value?.meta?.totalCount || 0);
 
 const extensionLoaders = ref<Record<string, any>>({});
 
-const { execute: updateExtension, error: updateError } = useEnfyraApi(
+const { execute: updateExtension, error: updateError } = useApi(
   () => `/extension_definition`,
   {
     method: "patch",
@@ -267,7 +267,7 @@ const toggleExtensionStatus = async (extension: ExtensionDefinition) => {
   });
 };
 
-const { execute: deleteExtensionApi, error: deleteError } = useEnfyraApi(
+const { execute: deleteExtensionApi, error: deleteError } = useApi(
   () => `/extension_definition`,
   {
     method: "delete",

--- a/app/pages/settings/general/index.vue
+++ b/app/pages/settings/general/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 const toast = useToast();
 const errors = ref<Record<string, string>>({});
 
@@ -35,7 +35,7 @@ const {
   data: apiData,
   pending: loading,
   execute: loadSetting,
-} = useEnfyraApi(() => `/setting_definition`, {
+} = useApi(() => `/setting_definition`, {
   query: {
     fields: "*",
     limit: 1,
@@ -56,7 +56,7 @@ const {
   execute: saveSetting,
   pending: saveLoading,
   error: saveError,
-} = useEnfyraApi(() => `/setting_definition/${setting.value.id}`, {
+} = useApi(() => `/setting_definition/${setting.value.id}`, {
   method: "patch",
   errorContext: "Save Settings",
 });

--- a/app/pages/settings/handlers/[id].vue
+++ b/app/pages/settings/handlers/[id].vue
@@ -99,7 +99,7 @@ const {
   data: handlerData,
   pending: loading,
   execute: executeGetHandler,
-} = useEnfyraApi(`/${tableName}`, {
+} = useApi(`/${tableName}`, {
   query: { fields: getIncludeFields(), filter: { id: { _eq: id } } },
   errorContext: "Fetch Handler",
 });
@@ -108,7 +108,7 @@ const {
   error: saveError,
   execute: executeSaveHandler,
   pending: saveLoading,
-} = useEnfyraApi(`/${tableName}`, {
+} = useApi(`/${tableName}`, {
   method: "patch",
   errorContext: "Save Handler",
 });
@@ -117,7 +117,7 @@ const {
   error: deleteError,
   execute: executeDeleteHandler,
   pending: deleteLoading,
-} = useEnfyraApi(`/${tableName}`, {
+} = useApi(`/${tableName}`, {
   method: "delete",
   errorContext: "Delete Handler",
 });

--- a/app/pages/settings/handlers/create.vue
+++ b/app/pages/settings/handlers/create.vue
@@ -54,13 +54,13 @@ useHeaderActionRegistry([
   },
 ]);
 
-// Setup useEnfyraApi composable at top level
+// Setup useApi composable at top level
 const {
   data: createData,
   error: createError,
   execute: executeCreateHandler,
   pending: createLoading,
-} = useEnfyraApi(() => `/${tableName}`, {
+} = useApi(() => `/${tableName}`, {
   method: "post",
   errorContext: "Create Handler",
 });

--- a/app/pages/settings/handlers/index.vue
+++ b/app/pages/settings/handlers/index.vue
@@ -14,7 +14,7 @@ const {
   data: apiData,
   pending: loading,
   execute: fetchRouteHandlers,
-} = useEnfyraApi(() => "/route_handler_definition", {
+} = useApi(() => "/route_handler_definition", {
   query: computed(() => ({
     fields: getIncludeFields(),
     sort: "-createdAt",
@@ -25,7 +25,7 @@ const {
   errorContext: "Fetch Route Handlers",
 });
 
-const { execute: removeHandler, error: removeHandlerError } = useEnfyraApi(
+const { execute: removeHandler, error: removeHandlerError } = useApi(
   () => `/route_handler_definition`,
   {
     method: "delete",

--- a/app/pages/settings/hooks/[id].vue
+++ b/app/pages/settings/hooks/[id].vue
@@ -49,7 +49,7 @@
 </template>
 
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 const route = useRoute();
 
 const toast = useToast();
@@ -108,7 +108,7 @@ const {
   data: hookData,
   pending: loading,
   execute: executeGetHook,
-} = useEnfyraApi(() => `/${tableName}`, {
+} = useApi(() => `/${tableName}`, {
   query: { fields: getIncludeFields(), filter: { id: { _eq: id } } },
   errorContext: "Fetch Hook",
 });
@@ -117,7 +117,7 @@ const {
   error: updateError,
   execute: executeUpdateHook,
   pending: updateLoading,
-} = useEnfyraApi(() => `/${tableName}`, {
+} = useApi(() => `/${tableName}`, {
   method: "patch",
   errorContext: "Update Hook",
 });
@@ -126,7 +126,7 @@ const {
   error: deleteError,
   execute: executeDeleteHook,
   pending: deleteLoading,
-} = useEnfyraApi(() => `/${tableName}`, {
+} = useApi(() => `/${tableName}`, {
   method: "delete",
   errorContext: "Delete Hook",
 });

--- a/app/pages/settings/hooks/create.vue
+++ b/app/pages/settings/hooks/create.vue
@@ -24,7 +24,7 @@
 </template>
 
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 const toast = useToast();
 
 const tableName = "hook_definition";
@@ -52,13 +52,13 @@ useHeaderActionRegistry({
   },
 });
 
-// Setup useEnfyraApi composable at top level
+// Setup useApi composable at top level
 const {
   data: createData,
   error: createError,
   execute: executeCreateHook,
   pending: createLoading,
-} = useEnfyraApi(() => `/${tableName}`, {
+} = useApi(() => `/${tableName}`, {
   method: "post",
   errorContext: "Create Hook",
 });

--- a/app/pages/settings/hooks/index.vue
+++ b/app/pages/settings/hooks/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 const toast = useToast();
 const { confirm } = useConfirm();
 const page = ref(1);
@@ -15,7 +15,7 @@ const {
   data: apiData,
   pending: loading,
   execute: fetchHooks,
-} = useEnfyraApi(() => "/hook_definition", {
+} = useApi(() => "/hook_definition", {
   query: computed(() => ({
     fields: getIncludeFields(),
     sort: "-createdAt",
@@ -27,7 +27,7 @@ const {
 });
 
 // Update API at setup level
-const { execute: updateHookApi, error: updateError } = useEnfyraApi(
+const { execute: updateHookApi, error: updateError } = useApi(
   () => `/hook_definition`,
   {
     method: "patch",
@@ -36,7 +36,7 @@ const { execute: updateHookApi, error: updateError } = useEnfyraApi(
 );
 
 // Delete API at setup level
-const { execute: deleteHookApi, error: deleteError } = useEnfyraApi(
+const { execute: deleteHookApi, error: deleteError } = useApi(
   () => `/hook_definition`,
   {
     method: "delete",

--- a/app/pages/settings/menus/[id].vue
+++ b/app/pages/settings/menus/[id].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 const route = useRoute();
 
 const toast = useToast();
@@ -20,7 +20,7 @@ const {
   data: menuData,
   pending: loading,
   execute: executeFetchMenu,
-} = useEnfyraApi(() => `/${tableName}`, {
+} = useApi(() => `/${tableName}`, {
   query: {
     fields: getIncludeFields(),
     filter: { id: { _eq: Number(route.params.id) } },
@@ -32,7 +32,7 @@ const {
   execute: executeUpdateMenu,
   pending: updateLoading,
   error: updateError,
-} = useEnfyraApi(() => `/${tableName}`, {
+} = useApi(() => `/${tableName}`, {
   method: "patch",
   errorContext: "Update Menu",
 });
@@ -41,7 +41,7 @@ const {
   execute: executeDeleteMenu,
   pending: deleteLoading,
   error: deleteError,
-} = useEnfyraApi(() => `/${tableName}`, {
+} = useApi(() => `/${tableName}`, {
   method: "delete",
   errorContext: "Delete Menu",
 });

--- a/app/pages/settings/menus/create.vue
+++ b/app/pages/settings/menus/create.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 const toast = useToast();
 
 const tableName = "menu_definition";
@@ -70,7 +70,7 @@ const {
   execute: createMenu,
   pending: creating,
   error: createError,
-} = useEnfyraApi(() => "/menu_definition", {
+} = useApi(() => "/menu_definition", {
   method: "post",
   errorContext: "Create Menu",
 });

--- a/app/pages/settings/menus/index.vue
+++ b/app/pages/settings/menus/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 
 const toast = useToast();
 const { confirm } = useConfirm();
@@ -34,7 +34,7 @@ const {
   data: apiData,
   pending: loading,
   execute: fetchMenus,
-} = useEnfyraApi(() => "/menu_definition", {
+} = useApi(() => "/menu_definition", {
   query: computed(() => {
     const filterQuery = hasActiveFilters(currentFilter.value)
       ? buildQuery(currentFilter.value)
@@ -157,7 +157,7 @@ async function toggleEnabled(menuItem: any, value?: boolean) {
   }
 
   // Create a specific instance for this menu update
-  const { execute: updateSpecificMenu, error: updateError } = useEnfyraApi(
+  const { execute: updateSpecificMenu, error: updateError } = useApi(
     () => `/menu_definition/${menuItem.id}`,
     {
       method: "patch",
@@ -203,7 +203,7 @@ async function deleteMenu(menuItem: any) {
   });
 
   if (isConfirmed) {
-    const { execute: deleteMenuApi, error: deleteError } = useEnfyraApi(
+    const { execute: deleteMenuApi, error: deleteError } = useApi(
       () => `/menu_definition/${menuItem.id}`,
       {
         method: "delete",

--- a/app/pages/settings/roles/[id].vue
+++ b/app/pages/settings/roles/[id].vue
@@ -37,7 +37,7 @@
 </template>
 
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 const route = useRoute();
 const toast = useToast();
 const { confirm } = useConfirm();
@@ -96,7 +96,7 @@ const {
   data: apiData,
   pending: loading,
   execute: fetchRole,
-} = useEnfyraApi(() => `/${tableName}`, {
+} = useApi(() => `/${tableName}`, {
   query: computed(() => ({
     fields: getIncludeFields(),
     filter: { id: { _eq: id } },
@@ -119,7 +119,7 @@ const {
   execute: updateRole,
   pending: updateLoading,
   error: updateError,
-} = useEnfyraApi(() => `/${tableName}/${id}`, {
+} = useApi(() => `/${tableName}/${id}`, {
   method: "patch",
   errorContext: "Update Role",
 });
@@ -128,7 +128,7 @@ const {
   execute: deleteRoleApi,
   pending: deleteLoading,
   error: deleteError,
-} = useEnfyraApi(() => `/${tableName}/${id}`, {
+} = useApi(() => `/${tableName}/${id}`, {
   method: "delete",
   errorContext: "Delete Role",
 });

--- a/app/pages/settings/roles/create.vue
+++ b/app/pages/settings/roles/create.vue
@@ -24,7 +24,7 @@
 </template>
 
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 const toast = useToast();
 
 const tableName = "role_definition";
@@ -34,13 +34,13 @@ const createErrors = ref<Record<string, string>>({});
 
 const { generateEmptyForm, validate } = useSchema(tableName);
 
-// Setup useEnfyraApi composable at top level
+// Setup useApi composable at top level
 const {
   data: createData,
   pending: createLoading,
   execute: createRole,
   error: createError,
-} = useEnfyraApi(() => `/${tableName}`, {
+} = useApi(() => `/${tableName}`, {
   method: "post",
   errorContext: "Create Role",
 });

--- a/app/pages/settings/roles/index.vue
+++ b/app/pages/settings/roles/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 const toast = useToast();
 const page = ref(1);
 const pageLimit = 10;
@@ -15,7 +15,7 @@ const {
   data: apiData,
   pending: loading,
   execute: fetchRoles,
-} = useEnfyraApi(() => "/role_definition", {
+} = useApi(() => "/role_definition", {
   query: computed(() => ({
     fields: getIncludeFields(),
     sort: "-createdAt",
@@ -49,7 +49,7 @@ useHeaderActionRegistry({
   },
 });
 
-const { execute: deleteRoleApi, error: deleteError } = useEnfyraApi(
+const { execute: deleteRoleApi, error: deleteError } = useApi(
   () => `/role_definition`,
   {
     method: "delete",

--- a/app/pages/settings/routings/[id].vue
+++ b/app/pages/settings/routings/[id].vue
@@ -63,7 +63,7 @@
 </template>
 
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 
 const route = useRoute();
 const toast = useToast();
@@ -121,7 +121,7 @@ const {
   data: routeData,
   pending: loading,
   execute: executeGetRoute,
-} = useEnfyraApi(`/${tableName}`, {
+} = useApi(`/${tableName}`, {
   query: {
     fields: getIncludeFields(),
     filter: { id: { _eq: route.params.id } },
@@ -133,7 +133,7 @@ const {
   error: updateError,
   execute: executeUpdateRoute,
   pending: updateLoading,
-} = useEnfyraApi(`/${tableName}`, {
+} = useApi(`/${tableName}`, {
   method: "patch",
   errorContext: "Update Route",
 });
@@ -142,7 +142,7 @@ const {
   error: deleteError,
   execute: executeDeleteRoute,
   pending: deleteLoading,
-} = useEnfyraApi(`/${tableName}`, {
+} = useApi(`/${tableName}`, {
   method: "delete",
   errorContext: "Delete Route",
 });

--- a/app/pages/settings/routings/create.vue
+++ b/app/pages/settings/routings/create.vue
@@ -24,7 +24,7 @@
 </template>
 
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 const toast = useToast();
 
 const tableName = "route_definition";
@@ -55,13 +55,13 @@ useHeaderActionRegistry([
   },
 ]);
 
-// Setup useEnfyraApi composable at top level
+// Setup useApi composable at top level
 const {
   data: createData,
   error: createError,
   execute: executeCreateRoute,
   pending: createLoading,
-} = useEnfyraApi(() => `/${tableName}`, {
+} = useApi(() => `/${tableName}`, {
   method: "post",
   errorContext: "Create Route",
 });

--- a/app/pages/settings/routings/index.vue
+++ b/app/pages/settings/routings/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 const toast = useToast();
 const page = ref(1);
 const pageLimit = 9;
@@ -33,7 +33,7 @@ const {
   data: apiData,
   pending: loading,
   execute: fetchRoutes,
-} = useEnfyraApi(() => "/route_definition", {
+} = useApi(() => "/route_definition", {
   query: computed(() => {
     const filterQuery = hasActiveFilters(currentFilter.value)
       ? buildQuery(currentFilter.value)
@@ -136,7 +136,7 @@ watch(
 );
 
 // Update API at setup level
-const { execute: updateRouteApi, error: updateError } = useEnfyraApi(
+const { execute: updateRouteApi, error: updateError } = useApi(
   () => `/route_definition`,
   {
     method: "patch",
@@ -145,7 +145,7 @@ const { execute: updateRouteApi, error: updateError } = useEnfyraApi(
 );
 
 // Delete API at setup level
-const { execute: deleteRouteApi, error: deleteError } = useEnfyraApi(
+const { execute: deleteRouteApi, error: deleteError } = useApi(
   () => `/route_definition`,
   {
     method: "delete",

--- a/app/pages/settings/users/[id].vue
+++ b/app/pages/settings/users/[id].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 const route = useRoute();
 const toast = useToast();
 const { confirm } = useConfirm();
@@ -13,7 +13,7 @@ const {
   data: apiData,
   pending: loading,
   execute: fetchUser,
-} = useEnfyraApi(() => "/user_definition", {
+} = useApi(() => "/user_definition", {
   query: computed(() => ({
     fields: "*",
     filter: {
@@ -42,7 +42,7 @@ const {
   execute: updateUser,
   pending: updateLoading,
   error: updateError,
-} = useEnfyraApi(() => `/user_definition/${route.params.id}`, {
+} = useApi(() => `/user_definition/${route.params.id}`, {
   method: "patch",
   errorContext: "Update User",
 });
@@ -51,7 +51,7 @@ const {
   execute: removeUser,
   pending: deleteLoading,
   error: deleteError,
-} = useEnfyraApi(() => `/user_definition/${route.params.id}`, {
+} = useApi(() => `/user_definition/${route.params.id}`, {
   method: "delete",
   errorContext: "Delete User",
 });

--- a/app/pages/settings/users/create.vue
+++ b/app/pages/settings/users/create.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 const toast = useToast();
 
 const tableName = "user_definition";
@@ -40,7 +40,7 @@ const {
   pending: createLoading,
   execute: createUser,
   error: createError,
-} = useEnfyraApi(() => `/${tableName}`, {
+} = useApi(() => `/${tableName}`, {
   method: "post",
   errorContext: "Create User",
 });

--- a/app/pages/settings/users/index.vue
+++ b/app/pages/settings/users/index.vue
@@ -93,7 +93,7 @@
   </div>
 </template>
 <script setup lang="ts">
-// useEnfyraApi is auto-imported in Nuxt
+// useApi is auto-imported in Nuxt
 const page = ref(1);
 const limit = 9;
 const tableName = "user_definition";
@@ -113,7 +113,7 @@ const {
   data: apiData,
   pending: loading,
   execute: fetchUsers,
-} = useEnfyraApi(() => `/${tableName}`, {
+} = useApi(() => `/${tableName}`, {
   query: computed(() => {
     const filterQuery = hasActiveFilters(currentFilter.value)
       ? buildQuery(currentFilter.value)
@@ -273,7 +273,7 @@ async function deleteUser(user: any) {
   });
 
   if (isConfirmed) {
-    const { execute: deleteUserApi, error: deleteError } = useEnfyraApi(
+    const { execute: deleteUserApi, error: deleteError } = useApi(
       () => `/${tableName}/${user.id}`,
       {
         method: "delete",

--- a/app/utils/extension/globals.ts
+++ b/app/utils/extension/globals.ts
@@ -74,7 +74,7 @@ export const NUXT_GLOBALS = {
 // Enfyra custom composables
 export const ENFYRA_GLOBALS = {
   // API
-  useEnfyraApi: true,
+  useApi: true,
   
   // Schema & Forms
   useSchema: true,
@@ -116,7 +116,7 @@ export const EXTENSION_GLOBALS = {
 // List of composables to inject into extension runtime
 export const EXTENSION_COMPOSABLES = {
   // Enfyra API composables
-  useEnfyraApi: 'useEnfyraApi',
+  useApi: 'useApi',
   useHeaderActionRegistry: 'useHeaderActionRegistry',
   useSubHeaderActionRegistry: 'useSubHeaderActionRegistry',
   useSchema: 'useSchema',


### PR DESCRIPTION
…ross all components and pages for consistency and improved clarity. Update comments to reflect the change in auto-imported API composable in Nuxt.