### PR TITLE
fix(nuxt-config): normalize API_URL by stripping trailing slashes

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -92,6 +92,7 @@ export default defineNuxtConfig({
     },
   },
   enfyraSDK: {
-    apiUrl: process.env.API_URL,
+    // Normalize to avoid trailing slash causing double // in requests
+    apiUrl: (process.env.API_URL || "").replace(/\/+$/, ""),
   },
 });


### PR DESCRIPTION
Prevents double “//” in requests when env has trailing “/” Applied in enfyraSDK.apiUrl via .replace(/\/+$/, "")