### PR TITLE
fix: correct v-model syntax in DateField component

### DIFF
--- a/app/components/form/DateField.vue
+++ b/app/components/form/DateField.vue
@@ -29,7 +29,7 @@
 
       <template #body>
         <div class="p-4">
-          <UCalendar v-model="tempValue as any" />
+          <UCalendar v-model="(tempValue as any)" />
         </div>
       </template>
 


### PR DESCRIPTION
- Updated the v-model binding in DateField.vue to ensure proper type casting with parentheses for improved clarity and functionality.