### PR TITLE
fix: prevent system menu check in handleChildrenReorder function

### DIFF
--- a/app/components/menu/MenuVisualEditorItem.vue
+++ b/app/components/menu/MenuVisualEditorItem.vue
@@ -74,7 +74,7 @@ function handleChildrenReorder(event: DragEvent) {
     if (!childMenuId) return;
     
     const originalMenu = allMenus.find(m => String(getId(m)) === String(childMenuId));
-    if (!originalMenu || originalMenu.isSystem) return;
+    if (!originalMenu) return;
     
     const oldOrder = originalMenu.order;
     if (oldOrder !== index) {


### PR DESCRIPTION
- Removed the check for system menus in the handleChildrenReorder function to allow reordering of non-system menus without restrictions.
- This change simplifies the logic for handling child menu reordering in the MenuVisualEditorItem component.