### PR TITLE
feat: add metadata banner with transitions and improve socket handling

### DIFF
--- a/app/assets/css/transitions.css
+++ b/app/assets/css/transitions.css
@@ -90,3 +90,26 @@
   opacity: 1;
   box-shadow: var(--shadow-glow);
 }
+
+.metadata-banner-enter-active,
+.metadata-banner-leave-active {
+  transition:
+    max-height 0.32s cubic-bezier(0.4, 0, 0.2, 1),
+    opacity 0.26s cubic-bezier(0.4, 0, 0.2, 1),
+    transform 0.32s cubic-bezier(0.4, 0, 0.2, 1);
+  overflow: hidden;
+}
+
+.metadata-banner-enter-from,
+.metadata-banner-leave-to {
+  max-height: 0;
+  opacity: 0;
+  transform: translateY(-0.5rem);
+}
+
+.metadata-banner-enter-to,
+.metadata-banner-leave-from {
+  max-height: 5rem;
+  opacity: 1;
+  transform: translateY(0);
+}

--- a/app/components/sidebar/UnifiedSidebar.vue
+++ b/app/components/sidebar/UnifiedSidebar.vue
@@ -6,7 +6,6 @@ const { checkPermissionCondition } = usePermissions();
 const { width } = useScreen();
 const { sidebarVisible, setSidebarVisible, settings } = useGlobalState();
 const { getFileUrl } = useFileUrl();
-const { metadataReloading } = useAdminSocket();
 
 if (import.meta.client) {
   const saved = localStorage.getItem('sidebar-open');
@@ -179,8 +178,7 @@ router.afterEach(() => {
     <template #title="{ state }">
       <div class="flex items-center gap-3 overflow-hidden">
         <div class="relative w-8 h-8 rounded-lg flex items-center justify-center overflow-hidden shrink-0">
-          <UIcon v-if="metadataReloading" name="lucide:loader-circle" class="text-primary animate-spin" size="20" />
-          <img v-else-if="faviconUrl" :src="faviconUrl" alt="Favicon" class="w-full h-full object-cover" />
+          <img v-if="faviconUrl" :src="faviconUrl" alt="Favicon" class="w-full h-full object-cover" />
           <UIcon v-else name="lucide:database" class="w-5 h-5 text-primary" />
         </div>
         <template v-if="state === 'expanded'">

--- a/app/composables/shared/useAdminSocket.ts
+++ b/app/composables/shared/useAdminSocket.ts
@@ -3,7 +3,9 @@ import { io, type Socket } from 'socket.io-client';
 import { ENFYRA_SOCKET_AUTH_ERROR } from '~/constants/enfyra';
 
 let socket: Socket | null = null;
-const metadataReloading = ref(false);
+let metadataReloadHideTimer: ReturnType<typeof setTimeout> | null = null;
+const METADATA_RELOAD_HIDE_MS = 200;
+export const metadataReloading = ref(false);
 
 export function useAdminSocket() {
   const toast = useToast();
@@ -50,12 +52,22 @@ export function useAdminSocket() {
 
     socket.on('$system:metadata:reload', async (data: { status: string }) => {
       if (data.status === 'pending') {
+        if (metadataReloadHideTimer) {
+          clearTimeout(metadataReloadHideTimer);
+          metadataReloadHideTimer = null;
+        }
         metadataReloading.value = true;
       } else if (data.status === 'done') {
         await schema.forceRefreshSchema();
         await routes.loadRoutes();
         await menuRegistry.registerDataMenuItems(Object.values(schema.schemas.value));
-        metadataReloading.value = false;
+        if (metadataReloadHideTimer) {
+          clearTimeout(metadataReloadHideTimer);
+        }
+        metadataReloadHideTimer = setTimeout(() => {
+          metadataReloading.value = false;
+          metadataReloadHideTimer = null;
+        }, METADATA_RELOAD_HIDE_MS);
       }
     });
 

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -29,6 +29,22 @@
         </div>
       </header>
 
+      <Transition name="metadata-banner">
+        <div
+          v-if="metadataReloading"
+          key="metadata-banner"
+          class="shrink-0 overflow-hidden"
+        >
+          <UBanner
+            color="neutral"
+            icon="lucide:loader-circle"
+            title="Loading metadata…"
+            class="border-b border-[var(--border-default)] shrink-0"
+            :ui="{ icon: 'animate-spin' }"
+          />
+        </div>
+      </Transition>
+
       <CommonPageHeader
         v-if="hasPageHeader"
         :key="`${pageHeader!.title}-${pageHeader?.description || ''}-${pageHeader?.variant || 'default'}-${pageHeader?.gradient || 'none'}-${pageHeader?.leadingIcon ?? ''}-${pageHeader?.hideLeadingIcon ? '0' : '1'}`"
@@ -59,6 +75,8 @@
 </template>
 
 <script setup lang="ts">
+import { metadataReloading } from '~/composables/shared/useAdminSocket';
+
 await useInitialData();
 await useMenuInit();
 useAppSettings();


### PR DESCRIPTION
- Introduced a metadata banner that displays a loading message during metadata reloads, enhancing user feedback.
- Added CSS transitions for the metadata banner to improve visual appearance during state changes.
- Updated socket handling in useAdminSocket to manage metadata reload state more effectively, including a timer for hiding the loading state.