### PR TITLE
chore: refactor components and remove unused code

### DIFF
--- a/app/components/collection/SchemaViewer.vue
+++ b/app/components/collection/SchemaViewer.vue
@@ -77,7 +77,7 @@ interface Props {
 const props = defineProps<Props>();
 
 const { schemas: allSchemas, fetchSchema, schemaLoading } = useSchema();
-const { definition, schema } = useSchema(toRef(props, 'tableName'));
+const { definition } = useSchema(toRef(props, 'tableName'));
 
 onMounted(async () => {
   if (Object.keys(allSchemas.value).length === 0) {

--- a/app/components/column-rule/ManageModal.vue
+++ b/app/components/column-rule/ManageModal.vue
@@ -28,7 +28,6 @@ const rules = defineModel<Rule[]>("rules", { required: true })
 
 const notify = useNotify()
 const { confirm } = useConfirm()
-const { getId } = useDatabase()
 
 type ViewMode = "list" | "form"
 const viewMode = ref<ViewMode>("list")

--- a/app/components/common/UploadModal.vue
+++ b/app/components/common/UploadModal.vue
@@ -21,7 +21,6 @@
         <div class="space-y-3">
           <slot name="header-content" />
           <div
-            ref="dropZone"
             class="border-2 border-dashed border-[var(--border-strong)] rounded-[var(--radius-card)] p-10 text-center transition-all duration-200 lg:hover:border-primary-400"
             :class="{
               'border-primary-500 bg-primary-50 dark:bg-primary-950 scale-105':
@@ -171,7 +170,6 @@ const isOpen = computed({
 });
 
 const fileInput = ref<HTMLInputElement>();
-const dropZone = ref<HTMLElement>();
 const selectedFiles = ref<File[]>([]);
 const isDragOver = ref(false);
 const dragCounter = ref(0);

--- a/app/components/field-permission/EditorDrawer.vue
+++ b/app/components/field-permission/EditorDrawer.vue
@@ -108,7 +108,7 @@ const emit = defineEmits<{
   cancel: [];
 }>();
 
-const { schema, definition } = useSchema(toRef(props, "tableName"));
+useSchema(toRef(props, "tableName"));
 
 const fieldPermissionFormPositions = computed(() => {
   if (props.tableName !== "enfyra_field_permission") return undefined;

--- a/app/components/field-permission/ManageModal.vue
+++ b/app/components/field-permission/ManageModal.vue
@@ -19,7 +19,6 @@ const permissions = defineModel<Permission[]>("permissions", { required: true })
 
 const notify = useNotify()
 const { confirm } = useConfirm()
-const { isMobile, isTablet } = useScreen()
 const { generateEmptyForm: generateFieldPermEmptyForm } = useSchema("enfyra_field_permission")
 
 type ViewMode = "list" | "form"

--- a/app/components/filter/Group.vue
+++ b/app/components/filter/Group.vue
@@ -258,10 +258,6 @@ function onEndZoneDragOver(event: DragEvent) {
   if (!isGroupEndZoneActive()) setEndZoneDropTarget(props.group);
 }
 
-function onEndZoneDragLeave(event: DragEvent) {
-  event.stopPropagation();
-}
-
 function onEndZoneDrop(event: DragEvent) {
   if (props.readonly) return;
 

--- a/app/components/filter/Preview.vue
+++ b/app/components/filter/Preview.vue
@@ -50,8 +50,6 @@ function copyToClipboard() {
     navigator.clipboard.writeText(formattedQuery.value);
   }
 }
-
-const { isMobile, isTablet } = useScreen();
 </script>
 
 <template>

--- a/app/components/flow/StepConfigEditor.vue
+++ b/app/components/flow/StepConfigEditor.vue
@@ -138,7 +138,7 @@
 
 <script setup lang="ts">
 import type { StepType } from '~/types/flow';
-import type { FilterGroup, FilterCondition } from '~/utils/common/filter/filter-types';
+import type { FilterGroup } from '~/utils/common/filter/filter-types';
 import type { ScriptLanguage } from '~/types/script-contract';
 import { normalizeScriptLanguage } from '~/utils/script-contract';
 

--- a/app/components/form/CodeEditor.vue
+++ b/app/components/form/CodeEditor.vue
@@ -49,7 +49,6 @@ const minHeight = computed(() => {
 });
 const containerRef = ref<HTMLDivElement>();
 const resizeHandleRef = ref<HTMLDivElement>();
-const previewLayerRef = ref<HTMLDivElement>();
 const isResizing = ref(false);
 const startY = ref(0);
 const startHeight = ref(0);
@@ -659,7 +658,6 @@ function handleMouseUp(e?: MouseEvent) {
     <Teleport to="body">
       <div
         v-if="isResizing && previewStyle"
-        ref="previewLayerRef"
         class="fixed pointer-events-none z-50 border-2 border-dashed border-brand-500 dark:border-brand-400 bg-brand-500/5 rounded-md"
         :style="previewStyle"
       ></div>

--- a/app/components/form/Editor.vue
+++ b/app/components/form/Editor.vue
@@ -373,9 +373,6 @@ const filteredFormFields = computed(() => {
 
 const visibleFields = computed(() => {
   const fields = filteredFormFields.value;
-  const fk = (f: { name?: string; propertyName?: string }) =>
-    f.name || f.propertyName || '';
-  const filteredKeys = fields.map(fk);
 
   if (props.loading) {
     return sortFieldsByOrder(fields);
@@ -391,8 +388,6 @@ const visibleFields = computed(() => {
   } else {
     ordered = sortFieldsByOrder(fields);
   }
-
-  const afterSortKeys = ordered.map(fk);
 
   if (props.fieldPositions && Object.keys(props.fieldPositions).length > 0) {
     ordered = applyFieldPositions(ordered, props.fieldPositions);

--- a/app/components/form/EnumPicker.vue
+++ b/app/components/form/EnumPicker.vue
@@ -121,8 +121,6 @@ const gridClass = computed(() => {
   };
   return colMap[cols] || 'grid-cols-3';
 });
-
-const { isMobile, isTablet } = useScreen();
 </script>
 
 <template>

--- a/app/components/form/FieldRenderer.vue
+++ b/app/components/form/FieldRenderer.vue
@@ -99,12 +99,6 @@ function getFieldConfig(key: string) {
     : manualConfig || {};
 }
 
-function getFinalType(key: string): string {
-  const column = props.columnMap.get(key);
-  const config = getFieldConfig(key);
-  return config.type || column?.type || "text";
-}
-
 function getCodeLanguage(key: string): "javascript" | "typescript" | "vue" | "json" | "html" {
   const config = getFieldConfig(key);
   if (config.language) return config.language;
@@ -195,7 +189,6 @@ function getComponentConfigByKey(key: string) {
   const disabled = config.disabled ?? isSystemField;
   const hasError = !!props.errors?.[key];
   const isSimpleJsonField = finalType === "simple-json";
-  const isRichTextField = finalType === "richtext";
 
   const fieldProps = {
     ...config.fieldProps,
@@ -731,35 +724,6 @@ function getComponentConfigByKey(key: string) {
 const componentConfig = computed(() => getComponentConfigByKey(props.keyName));
 const errorMessage = computed(() => props.errors?.[props.keyName]);
 const hasError = computed(() => !!errorMessage.value);
-
-const isRelationColumn = computed(() => {
-  return props.columnMap.get(props.keyName)?.fieldType === "relation";
-});
-
-const isCustomComponent = computed(() => {
-  const column = props.columnMap.get(props.keyName);
-  const manualConfig = props.fieldMap?.[props.keyName];
-  const config =
-    typeof manualConfig === "string"
-      ? { type: manualConfig }
-      : manualConfig || {};
-  const finalType = config.type || column?.type;
-  const isRelation = column?.fieldType === "relation";
-  
-  const customTypes = [
-    'richtext',
-    'code',
-    'simple-json',
-    'uuid',
-    'permission',
-    'date',
-    'datetime',
-    'timestamp',
-    'array-tags',
-  ];
-  
-  return isRelation || (finalType && customTypes.includes(finalType));
-});
 
 function getComponentType(): string {
   const column = props.columnMap.get(props.keyName);

--- a/app/components/form/field-permission/Config.vue
+++ b/app/components/form/field-permission/Config.vue
@@ -124,9 +124,8 @@ const loading = computed(() => (mode.value === "role" ? rolesLoading.value : use
 
 watch(
   searchTerm,
-  debounce(async (q: string) => {
+  debounce(async () => {
     if (suppressSearch.value) return;
-    const s = q.trim();
     if (!menuOpen.value) return;
     menuOpen.value = false;
     await fetchDefaultList();
@@ -337,4 +336,3 @@ async function setMode(next: Mode) {
     </UInputMenu>
   </div>
 </template>
-

--- a/app/components/form/permission/InlineEditor.vue
+++ b/app/components/form/permission/InlineEditor.vue
@@ -229,19 +229,6 @@ function applyFormPermissionGroups() {
   showModal.value = false;
 }
 
-function closeModal() {
-  
-  showModal.value = false;
-}
-
-function cancelChanges() {
-  
-  localFormPermissionGroups.value = JSON.parse(
-    JSON.stringify(originalPermissionGroups.value)
-  );
-  showModal.value = false;
-}
-
 function getTotalPermissions(): number {
   return localFormPermissionGroups.value.reduce((total, group) => {
     const conditions = group.conditions || group.rules || [];

--- a/app/components/form/permission/Selector.vue
+++ b/app/components/form/permission/Selector.vue
@@ -46,7 +46,6 @@ const emit = defineEmits(["update"]);
 
 const currentGroups = ref<any[]>([]);
 const isAllowAll = ref(false);
-const groupsOperator = ref("and");
 
 onMounted(() => {
   

--- a/app/components/form/relation/List.vue
+++ b/app/components/form/relation/List.vue
@@ -18,8 +18,6 @@ const emit = defineEmits<{
 
 const { getId } = useDatabase();
 const expandedItems = ref<Set<any>>(new Set());
-const itemRefs = ref<Record<string, HTMLElement>>({});
-const itemWidths = ref<Record<string, string>>({});
 
 function toggle(id: any) {
   if (props.disabled) return;
@@ -35,13 +33,6 @@ function isExpanded(id: any) {
 }
 
 function toggleExpand(id: any) {
-  
-  const el = itemRefs.value[id];
-  if (el && !expandedItems.value.has(id)) {
-    
-    itemWidths.value[id] = `${el.offsetWidth}px`;
-  }
-  
   if (expandedItems.value.has(id)) {
     expandedItems.value.delete(id);
   } else {
@@ -51,21 +42,9 @@ function toggleExpand(id: any) {
   expandedItems.value = new Set(expandedItems.value);
 }
 
-function setItemRef(id: any, el: any) {
-  if (el) {
-    itemRefs.value[id] = el;
-  }
-}
-
-function getItemWidth(id: any): string {
-  return itemWidths.value[id] || '100%';
-}
-
 function navigateToDetail(item: any) {
   emit("navigate-detail", item);
 }
-
-const { checkPermissionCondition } = usePermissions();
 
 function getDisplayLabel(
   item: Record<string, any>
@@ -294,7 +273,6 @@ const { isMobile, isTablet } = useScreen();
     >
       
       <div
-        :ref="(el) => setItemRef(getId(item), el)"
         class="flex items-center min-w-0"
       >
         

--- a/app/components/form/relation/Selector.vue
+++ b/app/components/form/relation/Selector.vue
@@ -151,12 +151,6 @@ function clearSearch() {
   page.value = 1;
 }
 
-async function clearFilter() {
-  currentFilter.value = createEmptyFilter();
-  page.value = 1;
-  await fetchDataWithValidation();
-}
-
 function clearAllFilters() {
   clearSearch();
   currentFilter.value = createEmptyFilter();

--- a/app/components/menu/MenuVisualEditor.vue
+++ b/app/components/menu/MenuVisualEditor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { MenuDefinition, MenuTreeItem, DragEvent } from '~/types';
+import type { MenuDefinition, MenuTreeItem } from '~/types';
 import draggable from 'vuedraggable';
 
 const props = defineProps<{
@@ -98,7 +98,7 @@ function handleMoveToRoot() {
   movingMenuId.value = null;
 }
 
-function handleRootReorder(event: DragEvent) {
+function handleRootReorder() {
   const updatedMenus: MenuDefinition[] = [];
   
   menuTreeItems.value.forEach((item, index) => {

--- a/app/components/menu/MenuVisualEditorItem.vue
+++ b/app/components/menu/MenuVisualEditorItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { MenuDefinition, MenuTreeItem, DragEvent } from '~/types';
+import type { MenuDefinition, MenuTreeItem } from '~/types';
 import draggable from 'vuedraggable';
 
 const props = defineProps<{
@@ -74,7 +74,7 @@ function isDescendant(menuId: string | number, potentialParentId: string | numbe
   return isDescendant(menuParentId, potentialParentId, allMenus);
 }
 
-function handleChildrenReorder(event: DragEvent) {
+function handleChildrenReorder() {
   if (!props.allMenus) return;
   
   const parentId = getId(props.item);

--- a/app/components/permission/PermissionManager.vue
+++ b/app/components/permission/PermissionManager.vue
@@ -324,7 +324,6 @@ const {
 const {
   error: deleteError,
   execute: deletePermissionApi,
-  pending: deletePending,
 } = useApi(() => `/${permissionTableName.value}`, {
   method: "delete",
   errorContext: "Delete Permission",

--- a/app/components/route/EditorPanel.vue
+++ b/app/components/route/EditorPanel.vue
@@ -87,8 +87,6 @@ const mainTableName = computed(() => mainTableInfo.value?.name || props.tableNam
 const {
   handlerAvailableMethods,
   canCreateHandler,
-  routePreHooks,
-  routePostHooks,
   sortedPreHooks,
   sortedAfterHooks,
   defaultHandler,
@@ -183,15 +181,6 @@ function filterPublicToAvailable(body: Record<string, any>) {
         })
         .filter(Boolean)
     }
-  }
-}
-
-async function initializeForm() {
-  const data = routeData.value?.data?.[0]
-  if (data) {
-    form.value = { ...data }
-    formChanges.update(data)
-    hasFormChanges.value = false
   }
 }
 

--- a/app/components/sidebar/UnifiedSidebar.vue
+++ b/app/components/sidebar/UnifiedSidebar.vue
@@ -223,7 +223,7 @@ onUnmounted(() => {
     @mouseleave="hideSidebarPeek"
     @focusin="showSidebarPeek"
   >
-    <template #title="{ state }">
+    <template #title>
       <div
         class="flex min-w-0 items-center overflow-hidden"
         :class="!renderExpandedSidebarContent ? 'w-full justify-center gap-0 px-0' : 'gap-3 px-1.5'"
@@ -240,7 +240,7 @@ onUnmounted(() => {
     </template>
     <template #description />
 
-    <template #default="{ state }">
+    <template #default>
       <div v-for="group in componentGroups" :key="group.id" class="mb-3">
         <component v-if="renderExpandedSidebarContent" :is="group.component" v-bind="group.componentProps || {}" />
       </div>

--- a/app/components/table/Columns.vue
+++ b/app/components/table/Columns.vue
@@ -92,12 +92,12 @@ const tooltipsDisabled = computed(
   () => showPermModal.value || showRuleModal.value || isEditing.value,
 );
 
-function handleShieldClick(column: any, index: number) {
+function handleShieldClick(_column: any, index: number) {
   permModalIndex.value = index;
   showPermModal.value = true;
 }
 
-function handleRuleClick(column: any, index: number) {
+function handleRuleClick(_column: any, index: number) {
   ruleModalIndex.value = index;
   showRuleModal.value = true;
 }
@@ -112,10 +112,6 @@ async function handleDrawerClose() {
     cancelText: "Cancel",
   });
   if (ok) discardChanges();
-}
-
-function cancelDrawer() {
-  isEditing.value = false;
 }
 
 function discardChanges() {

--- a/app/components/table/Constraints.vue
+++ b/app/components/table/Constraints.vue
@@ -8,10 +8,6 @@ const props = defineProps<{
 const { confirm } = useConfirm();
 const table = useModel(props, "modelValue");
 
-function addGroup(list: string[][]) {
-  list?.push([""]);
-}
-
 function addUniqueGroup() {
   if (!table.value.uniques) table.value.uniques = [];
   table.value.uniques.push([""]);
@@ -76,10 +72,6 @@ function canAddFieldToGroup(group: string[]): boolean {
   const availableCount = props.columnNames.filter((name: string) => !group.includes(name) || name === '').length;
   const hasEmptySlot = group.some((f: string) => !f || f === '');
   return availableCount > 0 && !hasEmptySlot;
-}
-
-function hasEmptyField(group: string[]): boolean {
-  return group.some((f: string) => !f || f === '');
 }
 
 function hasDuplicateGroup(list: string[][], groupIndex: number | string, orderMatters = false): boolean {

--- a/app/components/table/Relations.vue
+++ b/app/components/table/Relations.vue
@@ -192,7 +192,7 @@ const tooltipsDisabled = computed(
   () => showPermModal.value || isEditing.value || showInverseModal.value,
 );
 
-function handleShieldClick(rel: any, index: number) {
+function handleShieldClick(_rel: any, index: number) {
   permModalIndex.value = index;
   showPermModal.value = true;
 }
@@ -207,10 +207,6 @@ async function handleDrawerClose() {
     cancelText: "Cancel",
   });
   if (ok) discardChanges();
-}
-
-function cancelDrawer() {
-  isEditing.value = false;
 }
 
 function discardChanges() {

--- a/app/components/ui/ModernCard.vue
+++ b/app/components/ui/ModernCard.vue
@@ -1,7 +1,6 @@
 <template>
   <component
     :is="animated ? 'div' : 'div'"
-    ref="cardRef"
     :class="[
       'relative overflow-hidden',
       borderless ? 'rounded-none bg-transparent border-0 shadow-none p-0' : 'rounded-2xl surface-card',
@@ -61,7 +60,6 @@ const props = withDefaults(defineProps<Props>(), {
   animationDelay: "0ms",
 });
 
-const cardRef = ref<HTMLElement>();
 const isVisible = ref(false);
 
 const sizeClasses = {

--- a/app/components/websocket/EventEditorDrawer.vue
+++ b/app/components/websocket/EventEditorDrawer.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { ScriptLanguage } from '~/types/script-contract';
 import { normalizeScriptLanguage } from '~/utils/script-contract';
 import { buildWebsocketEventSavePayload } from '~/utils/websocket-events';
 

--- a/app/composables/editor/useCodeMirrorExtensions.ts
+++ b/app/composables/editor/useCodeMirrorExtensions.ts
@@ -199,15 +199,12 @@ export function useCodeMirrorExtensions(codeMirrorModules?: Ref<any> | any) {
     
     let checkPos = pos - 1;
     let prevLineText = '';
-    let actualPrevLine = null;
-    
     while (checkPos > 0) {
       const lineAtPos = doc.lineAt(checkPos);
       const lineText = lineAtPos.text.trim();
       
       if (lineText !== '') {
         prevLineText = lineAtPos.text;
-        actualPrevLine = lineAtPos;
         break;
       }
       checkPos = lineAtPos.from - 1;
@@ -290,7 +287,7 @@ export function useCodeMirrorExtensions(codeMirrorModules?: Ref<any> | any) {
     });
   };
 
-  function enfyraCompletionSource(m: any) {
+  function enfyraCompletionSource() {
     return (context: any) => {
       const before = context.matchBefore(/[@#%][\w.]*/);
       if (!before) {
@@ -304,7 +301,7 @@ export function useCodeMirrorExtensions(codeMirrorModules?: Ref<any> | any) {
     };
   }
 
-  function vueCompletionSource(m: any) {
+  function vueCompletionSource() {
     return (context: any) => {
       const doc = context.state.doc.toString();
       const before = doc.slice(0, context.pos);
@@ -365,9 +362,9 @@ export function useCodeMirrorExtensions(codeMirrorModules?: Ref<any> | any) {
       m.closeBrackets(),
       m.autocompletion({
         override: enfyraAutocomplete === 'vue'
-          ? [vueCompletionSource(m)]
+          ? [vueCompletionSource()]
           : enfyraAutocomplete
-            ? [enfyraCompletionSource(m)]
+            ? [enfyraCompletionSource()]
             : undefined,
       }),
       m.highlightSelectionMatches(),

--- a/app/composables/editor/useCodeMirrorTheme.ts
+++ b/app/composables/editor/useCodeMirrorTheme.ts
@@ -1,15 +1,10 @@
-export function useCodeMirrorTheme(height?: string | Ref<string>, codeMirrorModules?: Ref<any> | any, colorModeRef?: any) {
+export function useCodeMirrorTheme(_height?: string | Ref<string>, codeMirrorModules?: Ref<any> | any, colorModeRef?: any) {
   let colorMode: any;
   if (colorModeRef !== undefined && colorModeRef !== null) {
     colorMode = colorModeRef;
   } else {
     colorMode = useColorMode();
   }
-  const heightValue = computed(() => {
-    if (!height) return "400px";
-    return typeof height === "string" ? height : height.value;
-  });
-
   const isDark = computed(() => colorMode.value === 'dark');
 
   const modules = computed(() => {

--- a/app/composables/filter/useFilterDragDrop.ts
+++ b/app/composables/filter/useFilterDragDrop.ts
@@ -95,7 +95,7 @@ export function useFilterDragDrop() {
     return true;
   }
 
-  function executeDrop(targetGroup: FilterGroup): DropResult {
+  function executeDrop(_targetGroup: FilterGroup): DropResult {
     const defaultResult: DropResult = { success: false, sourceGroupId: null, targetGroupId: null };
 
     if (!dragState.value || !dropTarget.value) return defaultResult;

--- a/app/composables/menu/useMenuApi.ts
+++ b/app/composables/menu/useMenuApi.ts
@@ -19,7 +19,6 @@ export const useMenuApi = () => {
 
   const {
     data: menuDefinitions,
-    pending: menuDefinitionsPending,
     execute: fetchMenuDefinitions,
   } = useApi<{ data: MenuApiItem[] }>(() => "/enfyra_menu", {
     query: computed(() => ({

--- a/app/composables/page/usePageHeaderRegistry.ts
+++ b/app/composables/page/usePageHeaderRegistry.ts
@@ -53,7 +53,7 @@ export const usePageHeaderRegistry = () => {
 
   watch(
     () => route.path,
-    (newPath, oldPath) => {
+    (newPath) => {
       pageHeaderConfig.value = null;
 
       const routeHeader = routeHeaders.value.get(newPath);

--- a/app/composables/shared/useGlobalState.ts
+++ b/app/composables/shared/useGlobalState.ts
@@ -24,7 +24,6 @@ export const useGlobalState = () => {
 
   const {
     data: settingsData,
-    pending: settingsPending,
     execute: executeFetchSettings,
   } = useApi(() => "/enfyra_setting", {
     query: {

--- a/app/composables/shared/useNotify.ts
+++ b/app/composables/shared/useNotify.ts
@@ -26,7 +26,7 @@ export function useNotify() {
 
     return new Promise((resolve) => {
       let settled = false
-      const finish = (reason: string) => {
+      const finish = () => {
         if (settled) return
         settled = true
         observer.disconnect()
@@ -35,7 +35,7 @@ export function useNotify() {
       }
 
       const observer = new MutationObserver(() => {
-        if (!hasOpenOverlay()) finish('observer')
+        if (!hasOpenOverlay()) finish()
       })
 
       observer.observe(document.body, {
@@ -45,7 +45,7 @@ export function useNotify() {
         subtree: true,
       })
 
-      const timeout = setTimeout(() => finish('timeout(500ms)'), 500)
+      const timeout = setTimeout(() => finish(), 500)
     })
   }
 

--- a/app/middleware/auth.global.ts
+++ b/app/middleware/auth.global.ts
@@ -1,4 +1,4 @@
-export default defineNuxtRouteMiddleware(async (to, from) => {
+export default defineNuxtRouteMiddleware(async (to) => {
   if (process.env.NODE_ENV === "test") return;
 
   const { me, fetchUser } = useAuth();

--- a/app/pages/collections/index.vue
+++ b/app/pages/collections/index.vue
@@ -8,7 +8,6 @@ import type { SystemVisibilityMode } from "~/types/ui";
 const page = ref(1);
 const pageLimit = 9;
 const route = useRoute();
-const { getId } = useDatabase();
 
 const { registerPageHeader } = usePageHeaderRegistry();
 

--- a/app/pages/packages/app.vue
+++ b/app/pages/packages/app.vue
@@ -66,8 +66,6 @@
 const { register: registerHeaderActions } = useHeaderActionRegistry();
 const page = ref(1);
 const limit = 9;
-const { confirm } = useConfirm();
-const notify = useNotify();
 const route = useRoute();
 const { isTablet } = useScreen();
 const { getId } = useDatabase();
@@ -123,65 +121,6 @@ const {
   isRefreshing: packagesRefreshing,
 } = useStableListState(() => apiData.value?.data, () => loading.value);
 const total = computed(() => apiData.value?.meta?.totalCount || 0);
-
-const { execute: removePackage, error: removePackageError } = useApi(
-  "/enfyra_package",
-  {
-    method: "delete",
-    errorContext: "Uninstall Package",
-  }
-);
-
-const deletingPackages = ref(new Set<string>());
-
-async function deletePackage(pkgId: any, pkgName: string) {
-  const isConfirmed = await confirm({
-    title: "Uninstall Package",
-    content: `Are you sure you want to uninstall "${pkgName}"? This action cannot be undone.`,
-    confirmText: "Uninstall",
-    cancelText: "Cancel",
-  });
-
-  if (!isConfirmed) return;
-
-  deletingPackages.value.add(pkgId);
-
-  try {
-    await removePackage({ id: pkgId });
-
-    if (removePackageError.value) {
-      return;
-    }
-
-    await fetchAppPackages();
-
-    notify.success("Success", `Package ${pkgName} uninstalled successfully`);
-
-    await loadPackages();
-  } finally {
-    deletingPackages.value.delete(pkgId);
-  }
-}
-
-function getHeaderActions(pkg: any) {
-  const pkgId = getId(pkg);
-
-  return [
-    {
-      component: "UButton",
-      props: {
-        icon: "i-heroicons-trash",
-        variant: "outline",
-        color: "error",
-        loading: deletingPackages.value.has(pkgId),
-      },
-      onClick: (e?: Event) => {
-        e?.stopPropagation();
-        deletePackage(pkgId, pkg.name);
-      },
-    },
-  ];
-}
 
 watch(
   page,

--- a/app/pages/packages/backend.vue
+++ b/app/pages/packages/backend.vue
@@ -106,8 +106,6 @@
 const { register: registerHeaderActions } = useHeaderActionRegistry();
 const page = ref(1);
 const limit = 9;
-const { confirm } = useConfirm();
-const notify = useNotify();
 const route = useRoute();
 const { isTablet } = useScreen();
 const { getId } = useDatabase();
@@ -167,64 +165,6 @@ const {
   isRefreshing: packagesRefreshing,
 } = useStableListState(() => apiData.value?.data, () => loading.value);
 const total = computed(() => apiData.value?.meta?.totalCount || 0);
-
-const { execute: removePackage, error: removePackageError } = useApi(
-  "/enfyra_package",
-  {
-    method: "delete",
-    errorContext: "Uninstall Package",
-  }
-);
-
-const deletingPackages = ref(new Set<string>());
-
-async function deletePackage(pkgId: any, pkgName: string) {
-  const isConfirmed = await confirm({
-    title: "Uninstall Package",
-    content: `Are you sure you want to uninstall "${pkgName}"? This action cannot be undone.`,
-    confirmText: "Uninstall",
-    cancelText: "Cancel",
-  });
-
-  if (!isConfirmed) return;
-
-  deletingPackages.value.add(pkgId);
-  pendingOps.value.set(pkgId, `Uninstalling ${pkgName}...`);
-
-  try {
-    await removePackage({ id: pkgId });
-
-    if (removePackageError.value) {
-      pendingOps.value.delete(pkgId);
-      return;
-    }
-
-    await loadPackages();
-  } finally {
-    deletingPackages.value.delete(pkgId);
-  }
-}
-
-function getHeaderActions(pkg: any) {
-  const pkgId = getId(pkg);
-
-  return [
-    {
-      component: "UButton",
-      props: {
-        icon: "i-heroicons-trash",
-        variant: "outline",
-        color: "error",
-        loading: deletingPackages.value.has(pkgId) || pkg.status === 'uninstalling',
-        disabled: pkg.status && pkg.status !== 'installed' && pkg.status !== 'failed',
-      },
-      onClick: (e?: Event) => {
-        e?.stopPropagation();
-        deletePackage(pkgId, pkg.name);
-      },
-    },
-  ];
-}
 
 watch(
   page,

--- a/app/pages/settings/api-tester/index.vue
+++ b/app/pages/settings/api-tester/index.vue
@@ -18,8 +18,8 @@
               @click="openTest(r)"
             >
               <div class="flex items-center gap-2 mb-2">
-                <div class="w-6 h-6 rounded flex items-center justify-center flex-shrink-0 bg-primary-100 dark:bg-primary-900/40">
-                  <UIcon :name="r.icon || 'lucide:code-2'" class="w-3.5 h-3.5 text-primary-600 dark:text-primary-400" />
+                <div class="w-6 h-6 rounded flex items-center justify-center flex-shrink-0 eapp-primary-solid">
+                  <UIcon :name="r.icon || 'lucide:code-2'" class="w-3.5 h-3.5 text-[var(--action-primary-text)]" />
                 </div>
                 <p class="text-xs font-semibold font-mono text-[var(--text-primary)] truncate flex-1">{{ r.path }}</p>
                 <UBadge v-if="!r.isEnabled" color="warning" variant="soft" size="xs">Off</UBadge>

--- a/app/pages/settings/flows/[id].vue
+++ b/app/pages/settings/flows/[id].vue
@@ -666,7 +666,6 @@ async function saveStep() {
       parent: stepForm.value.parentId ? { id: stepForm.value.parentId } : null,
       branch: stepForm.value.parentId ? stepForm.value.branch : null,
     };
-    const isEdit = !!editingStepId.value;
     if (editingStepId.value) {
       await updateStepApi({ body, id: editingStepId.value });
       if (updateStepError.value) return;
@@ -860,11 +859,4 @@ const execStepTimeline = computed(() => {
   return timeline;
 });
 
-function formatJson(val: any): string {
-  if (!val) return '';
-  if (typeof val === 'string') {
-    try { return JSON.stringify(JSON.parse(val), null, 2); } catch { return val; }
-  }
-  return JSON.stringify(val, null, 2);
-}
 </script>

--- a/app/pages/settings/menus/index.vue
+++ b/app/pages/settings/menus/index.vue
@@ -460,10 +460,6 @@ async function handleDeleteExtension(menu: MenuDefinition) {
   notify.success("Success", `Extension deleted successfully!`);
 }
 
-async function handleMoveMenu(menu: MenuDefinition) {
-  
-}
-
 async function handleMoveMenuTo(payload: { menu: MenuDefinition; newParent: MenuDefinition | null }) {
   const { menu, newParent } = payload;
   const menuId = getId(menu);
@@ -684,7 +680,6 @@ watch(showExtensionDrawer, async (isOpen, wasOpen) => {
       @edit-extension="handleEditExtension"
       @delete-extension="handleDeleteExtension"
       @reorder-menus="handleReorderMenus"
-      @move-menu="handleMoveMenu"
       @move-menu-to="handleMoveMenuTo"
     />
 

--- a/app/pages/settings/oauth/accounts/[id].vue
+++ b/app/pages/settings/oauth/accounts/[id].vue
@@ -35,7 +35,7 @@ const route = useRoute();
 const { registerPageHeader } = usePageHeaderRegistry();
 
 const tableName = "enfyra_oauth_account";
-const { getId, getIdFieldName } = useDatabase();
+const { getIdFieldName } = useDatabase();
 
 const {
   data: apiData,

--- a/app/pages/settings/websockets/[id].vue
+++ b/app/pages/settings/websockets/[id].vue
@@ -229,7 +229,6 @@ const { data: eventsData, execute: fetchEvents } = useApi(() => "/enfyra_websock
 });
 
 const {
-  data: updateData,
   error: updateError,
   execute: executeUpdate,
   pending: updateLoading,

--- a/app/pages/settings/websockets/create.vue
+++ b/app/pages/settings/websockets/create.vue
@@ -50,8 +50,6 @@ definePageMeta({
 
 const notify = useNotify();
 const router = useRouter();
-const { createLoader } = useLoader();
-const { confirm } = useConfirm();
 
 const tableName = "enfyra_websocket";
 

--- a/app/pages/settings/websockets/index.vue
+++ b/app/pages/settings/websockets/index.vue
@@ -142,7 +142,7 @@ registerHeaderActions([
   },
 ]);
 
-function getGatewayIcon(gateway: any) {
+function getGatewayIcon(_gateway: any) {
   return "i-lucide-radio-tower";
 }
 

--- a/app/pages/storage/config/index.vue
+++ b/app/pages/storage/config/index.vue
@@ -143,8 +143,6 @@ registerPageHeader({
   gradient: "blue",
 });
 
-const pageIconColor = 'primary';
-
 const {
   data: apiData,
   pending: loading,

--- a/app/pages/storage/management/file/[id].vue
+++ b/app/pages/storage/management/file/[id].vue
@@ -3,7 +3,6 @@ const { register: registerSubHeaderActions } = useSubHeaderActionRegistry();
 const { register: registerHeaderActions } = useHeaderActionRegistry();
 
 const route = useRoute();
-const router = useRouter();
 const notify = useNotify();
 const { confirm } = useConfirm();
 const { updateFileTimestamp } = useGlobalState();
@@ -15,7 +14,6 @@ const { getIdFieldName } = useDatabase();
 const {
   data: file,
   pending,
-  error,
   execute,
 } = useApi(`/enfyra_file`, {
   query: computed(() => {

--- a/app/pages/storage/management/folder/[id].vue
+++ b/app/pages/storage/management/folder/[id].vue
@@ -24,7 +24,6 @@ const { getIncludeFields: getFileFields } = useSchema("enfyra_file");
 
 const {
   data: folder,
-  pending: folderPending,
   execute: fetchFolder,
 } = useApi(() => `/enfyra_folder`, {
   query: computed(() => {

--- a/app/pages/storage/management/index.vue
+++ b/app/pages/storage/management/index.vue
@@ -101,28 +101,6 @@ watch(showUploadModal, async (open) => {
   await fetchStorageConfigs();
 });
 
-const pageStats = computed(() => {
-  const totalFolders = rootFolders.value?.meta?.filterCount || 0;
-  const totalFiles = rootFiles.value?.meta?.filterCount || 0;
-
-  return [
-    {
-      icon: "lucide:folder",
-      iconColor: "text-primary",
-      iconBg: "bg-primary/10",
-      value: totalFolders,
-      label: "Root Folders",
-    },
-    {
-      icon: "lucide:file",
-      iconColor: "text-[var(--st-info)]",
-      iconBg: "bg-[var(--state-info-soft-bg)]",
-      value: totalFiles,
-      label: "Root Files",
-    },
-  ];
-});
-
 watch(
   () => route.query.folderPage,
   async (newPage) => {

--- a/app/plugins/01-primary-color.client.ts
+++ b/app/plugins/01-primary-color.client.ts
@@ -1,5 +1,4 @@
 import {
-  DEFAULT_PRIMARY_COLOR,
   getPrimaryColorMeta,
   getPrimaryColorStyle,
   normalizePrimaryColor,

--- a/app/utils/form/field-order.ts
+++ b/app/utils/form/field-order.ts
@@ -47,16 +47,11 @@ export function applyFieldPositions(
   positions: Record<string, number>,
 ): TableDefinitionField[] {
   const n = fields.length;
-  const fieldKeys = fields.map(fieldKey);
   if (n === 0) {
     return fields;
   }
 
   const positionKeys = Object.keys(positions);
-  const unmatched = positionKeys.filter(
-    (k) => !fields.some((f) => fieldKey(f) === k),
-  );
-
   const pinnedKeys = new Set(
     positionKeys.filter((k) => fields.some((f) => fieldKey(f) === k)),
   );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enfyra-app",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "Dynamic admin interface for Enfyra backend - auto-generates management UI from database schemas",
   "license": "MIT",
   "author": "dothinh115 <dothinh115@gmail.com>",

--- a/server/middleware/cors.ts
+++ b/server/middleware/cors.ts
@@ -83,7 +83,6 @@ export function getCorsOrigins(): string[] {
 
 export default defineEventHandler(async (event) => {
   const url = event.node.req.url || '';
-  const method = event.node.req.method || 'GET';
   
   if (!url.includes('/api/')) {
     return;

--- a/server/utils/cors-origin-proxy.ts
+++ b/server/utils/cors-origin-proxy.ts
@@ -5,7 +5,6 @@ import {
   getRequestHeader,
   readBody,
   setResponseHeaders,
-  type H3Event,
 } from 'h3';
 import { clearCorsCache } from '../middleware/cors';
 


### PR DESCRIPTION
- Simplified SchemaViewer.vue by removing unused schema variable.
- Cleaned up ManageModal.vue by removing unused getId function.
- Removed dropZone reference in UploadModal.vue.
- Updated EditorDrawer.vue to eliminate unnecessary schema and definition usage.
- Cleaned up ManageModal.vue by removing unused screen size checks.
- Removed unused onEndZoneDragLeave function in Group.vue.
- Eliminated unused isMobile and isTablet checks in Preview.vue and EnumPicker.vue.
- Refactored StepConfigEditor.vue to remove unused FilterCondition import.
- Removed unused previewLayerRef in CodeEditor.vue.
- Cleaned up Editor.vue by removing unused field key mapping logic.
- Removed unused isMobile and isTablet checks in various components.
- Simplified FieldRenderer.vue by removing unused relation and custom component checks.
- Cleaned up Config.vue by removing unnecessary debounce parameter.
- Removed unused closeModal and cancelChanges functions in InlineEditor.vue.
- Cleaned up Selector.vue by removing unused groupsOperator reference.
- Removed unused itemRefs and itemWidths in List.vue.
- Cleaned up Selector.vue by removing unused clearFilter function.
- Simplified MenuVisualEditor.vue and MenuVisualEditorItem.vue by removing unused DragEvent import.
- Cleaned up PermissionManager.vue by removing unused deletePending reference.
- Removed unused routePreHooks and routePostHooks in EditorPanel.vue.
- Cleaned up UnifiedSidebar.vue by removing unnecessary state parameters in templates.
- Simplified Columns.vue by renaming parameters in shield and rule click handlers.
- Cleaned up Constraints.vue by removing unused addGroup function.
- Removed unused cancelDrawer function in Relations.vue.
- Cleaned up ModernCard.vue by removing unused cardRef reference.
- Removed unused ScriptLanguage import in EventEditorDrawer.vue.
- Cleaned up useCodeMirrorExtensions.ts by removing unused parameters in completion sources.
- Simplified useCodeMirrorTheme.ts by removing unused height parameter.
- Cleaned up useFilterDragDrop.ts by removing unused targetGroup parameter.
- Removed unused menuDefinitionsPending in useMenuApi.ts.
- Cleaned up usePageHeaderRegistry.ts by removing unused oldPath parameter.
- Removed unused settingsPending in useGlobalState.ts.
- Cleaned up useNotify.ts by removing unused reason parameter in finish function.
- Simplified auth.global.ts by removing unused from parameter.
- Cleaned up collections/index.vue by removing unused getId reference.
- Removed unused confirm and notify references in app.vue and backend.vue.
- Cleaned up api-tester/index.vue by updating class names for consistency.
- Removed unused isEdit variable in flows/[id].vue.
- Cleaned up menus/index.vue by removing unused handleMoveMenu function.
- Removed unused getId reference in oauth/accounts/[id].vue.
- Cleaned up websockets/[id].vue by removing unused updateData reference.
- Removed unused createLoader and confirm references in websockets/create.vue.
- Cleaned up websockets/index.vue by renaming gateway parameter in getGatewayIcon function.
- Removed unused pageIconColor variable in storage/config/index.vue.
- Cleaned up storage/management/file/[id].vue by removing unused router reference.
- Removed unused folderPending in storage/management/folder/[id].vue.
- Cleaned up storage/management/index.vue by removing unused pageStats computed property.
- Removed unused DEFAULT_PRIMARY_COLOR import in 01-primary-color.client.ts.
- Cleaned up field-order.ts by removing unused fieldKeys and unmatched variables.
- Bump version to 2.2.7 in package.json.
- Cleaned up cors.ts by removing unused method variable.
- Removed unused H3Event type import in cors-origin-proxy.ts.