### PR TITLE
Release v2.2.16-patch-1

### DIFF
--- a/app/pages/collections/[table].vue
+++ b/app/pages/collections/[table].vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { isSchemaMutationPreviewResponse } from '~/utils/schema/schema-confirm';
+
 const { register: registerSubHeaderActions } = useSubHeaderActionRegistry();
 const { register: registerHeaderActions } = useHeaderActionRegistry();
 const route = useRoute();
@@ -14,6 +16,7 @@ const table = ref<any>();
 const schemaConfirmModalOpen = ref(false);
 const schemaConfirmDetails = ref<any>(null);
 const schemaConfirmLoading = ref(false);
+const schemaConfirmOperation = ref<'update' | 'delete'>('update');
 
 const deleteModalOpen = ref(false);
 const deleteConfirmText = ref("");
@@ -261,8 +264,9 @@ async function patchTable() {
   if (updateError.value) return;
 
   const preview = patchTableData.value?.data?.[0];
-  if (preview?._preview) {
+  if (isSchemaMutationPreviewResponse(patchTableData.value)) {
     schemaConfirmDetails.value = preview;
+    schemaConfirmOperation.value = 'update';
     schemaConfirmModalOpen.value = true;
     return;
   }
@@ -313,8 +317,16 @@ async function executeDelete() {
   }
 
   deleteModalOpen.value = false;
-  await executeDeleteTable({ id: getId(table.value) });
+  const deletionResponse = await executeDeleteTable({ id: getId(table.value) });
   if (deleteError.value) return;
+
+  if (isSchemaMutationPreviewResponse(deletionResponse)) {
+    schemaConfirmDetails.value = deletionResponse.data?.[0];
+    schemaConfirmOperation.value = 'delete';
+    schemaConfirmModalOpen.value = true;
+    return;
+  }
+
   await afterDeleteSuccess(String(route.params.table));
 }
 
@@ -418,9 +430,30 @@ async function onSchemaConfirmSubmit() {
     const confirmQuery = {
       schema_confirm_hash: schemaConfirmDetails.value?.requiredConfirmHash,
     };
-    await executePatchTable({ id: getId(table.value), body: table.value, query: confirmQuery });
+    if (schemaConfirmOperation.value === 'delete') {
+      const confirmationResponse = await executeDeleteTable({
+        id: getId(table.value),
+        query: confirmQuery,
+      });
+      if (deleteError.value) return;
+      if (isSchemaMutationPreviewResponse(confirmationResponse)) {
+        schemaConfirmDetails.value = confirmationResponse.data?.[0];
+        notify.error('Confirmation not applied', 'The schema deletion still requires confirmation.');
+        return;
+      }
+      schemaConfirmModalOpen.value = false;
+      await afterDeleteSuccess(String(route.params.table));
+      return;
+    }
+    const confirmationResponse = await executePatchTable({ id: getId(table.value), body: table.value, query: confirmQuery });
     if (updateError.value) {
       schemaConfirmModalOpen.value = false;
+      return;
+    }
+    if (isSchemaMutationPreviewResponse(confirmationResponse)) {
+      const preview = (confirmationResponse as any)?.data?.[0];
+      schemaConfirmDetails.value = preview;
+      notify.error('Confirmation not applied', 'The schema mutation still requires confirmation.');
       return;
     }
     schemaConfirmModalOpen.value = false;
@@ -490,7 +523,7 @@ onMounted(async () => {
                   <span class="font-bold font-mono">{{ schemaConfirmTableName }}</span>
                 </div>
                 <div class="mt-1 text-xs text-[var(--text-tertiary)]">
-                  Operation: update
+                Operation: {{ schemaConfirmOperation }}
                 </div>
               </div>
               <div

--- a/app/utils/enfyra/runtime/api-url.ts
+++ b/app/utils/enfyra/runtime/api-url.ts
@@ -1,0 +1,3 @@
+export function resolvePublicApiUrl(env: Record<string, string | undefined>): string | undefined {
+  return (env.NUXT_PUBLIC_API_URL || env.API_URL)?.replace(/\/+$/, '')
+}

--- a/app/utils/schema/schema-confirm.ts
+++ b/app/utils/schema/schema-confirm.ts
@@ -1,0 +1,4 @@
+export function isSchemaMutationPreviewResponse(response: unknown): boolean {
+  const record = (response as { data?: unknown[] } | null)?.data?.[0];
+  return Boolean(record && typeof record === 'object' && (record as { _preview?: unknown })._preview === true);
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,3 +1,5 @@
+import { resolvePublicApiUrl } from './app/utils/enfyra/runtime/api-url'
+
 export default defineNuxtConfig({
   srcDir: 'app',
   compatibilityDate: "2025-05-15",
@@ -154,7 +156,7 @@ export default defineNuxtConfig({
   },
   runtimeConfig: {
     public: {
-      apiUrl: process.env.API_URL?.replace(/\/+$/, ''),
+      apiUrl: resolvePublicApiUrl(process.env),
       demoLoginPrefill: process.env.NUXT_PUBLIC_DEMO_LOGIN_PREFILL === 'true',
     },
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enfyra-app",
-  "version": "2.2.16",
+  "version": "2.2.16-patch-1",
   "description": "Dynamic admin interface for Enfyra backend - auto-generates management UI from database schemas",
   "license": "MIT",
   "author": "dothinh115 <dothinh115@gmail.com>",

--- a/tests/unit/runtime-api-url.test.ts
+++ b/tests/unit/runtime-api-url.test.ts
@@ -1,0 +1,10 @@
+import { resolvePublicApiUrl } from '~/utils/enfyra/runtime/api-url'
+
+describe('resolvePublicApiUrl', () => {
+  it('uses the Nuxt runtime override instead of the build-time API_URL default', () => {
+    expect(resolvePublicApiUrl({
+      API_URL: 'http://build-time-api:1105/',
+      NUXT_PUBLIC_API_URL: 'http://runtime-api:1105/',
+    })).toBe('http://runtime-api:1105')
+  })
+})

--- a/tests/unit/schema-confirm.test.ts
+++ b/tests/unit/schema-confirm.test.ts
@@ -1,0 +1,22 @@
+import { isSchemaMutationPreviewResponse } from '~/utils/schema/schema-confirm';
+
+describe('schema confirmation responses', () => {
+  it('recognizes a backend preview response', () => {
+    expect(isSchemaMutationPreviewResponse({ data: [{ _preview: true }] })).toBe(true);
+  });
+
+  it('recognizes a destructive DELETE preview response', () => {
+    expect(isSchemaMutationPreviewResponse({
+      data: [{
+        _preview: true,
+        isDestructive: true,
+        requiredConfirmHash: 'delete-confirm-hash',
+      }],
+    })).toBe(true);
+  });
+
+  it('does not treat an applied mutation as a preview', () => {
+    expect(isSchemaMutationPreviewResponse({ data: [{ mutationId: 'mutation-1' }] })).toBe(false);
+    expect(isSchemaMutationPreviewResponse(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed collection schema preview handling for PATCH and DELETE confirmations.
- Fixed runtime API URL resolution for production eApp proxying.
- Bumped eApp version to 2.2.16-patch-1.

## Verification
- yarn nuxi typecheck
- focused schema confirmation and runtime API URL tests